### PR TITLE
Do not open issues when they are contained in a blurred column

### DIFF
--- a/src/Components/Column.js
+++ b/src/Components/Column.js
@@ -84,7 +84,7 @@ export default function({loaded, columns, isConnected, isMobile}) {
                   {column.language.name}
                 </Subheader>
                 <div>
-                  <Issue issues={column.issues} loaded={loaded} />
+                  <Issue issues={column.issues} loaded={loaded} parentClasses={classNames('column', {['column-blur']: (!isConnected && index > 1)})} />
                 </div>
               </List>
             </span>

--- a/src/Components/Issue.js
+++ b/src/Components/Issue.js
@@ -37,11 +37,15 @@ const style = {
   marginTop: '-28px',
 };
 
-export default function Issue({loaded, issues}) {
+export default function Issue({loaded, issues, parentClasses}) {
   const avatar = src => loaded ? <Avatar src={src} /> : <Avatar />;
 
   function createOpen(issue) {
     return () => {
+      // Do not allow user to open issue on blur columns
+      if (parentClasses.indexOf('column-blur') !== -1) {
+        return;
+      }
       window.ga('send', 'event', 'issue', 'opened', issue.title);
       window.open(issue.html_url);
     };


### PR DESCRIPTION
Currently issues contained in a blurred columns can be openned, I don't think it's the wanted behavior 

![gif](https://user-images.githubusercontent.com/1689750/31656842-27cbdef0-b32d-11e7-9be3-d10bc34cb669.gif)
